### PR TITLE
Reinstates logic to disconnect congested peers

### DIFF
--- a/rust/saito-core/src/core/routing_thread.rs
+++ b/rust/saito-core/src/core/routing_thread.rs
@@ -783,18 +783,18 @@ impl RoutingThread {
     }
 
     async fn manage_congested_peers(&mut self) {
-        // let peers = self.network.peer_lock.write().await;
-        // let current_time = self.timer.get_timestamp_in_ms();
-        // let congested_peers: Vec<PeerIndex> = peers.get_congested_peers(current_time);
-        // drop(peers);
+        let peers = self.network.peer_lock.write().await;
+        let current_time = self.timer.get_timestamp_in_ms();
+        let congested_peers: Vec<PeerIndex> = peers.get_congested_peers(current_time);
+        drop(peers);
 
-        // for peer_index in congested_peers {
-        //     warn!("peer : {:?} is congested. so disconnecting...", peer_index);
-        //     self.network
-        //         .io_interface
-        //         .disconnect_from_peer(peer_index)
-        //         .await;
-        // }
+        for peer_index in congested_peers {
+            warn!("peer : {:?} is congested. so disconnecting...", peer_index);
+            self.network
+                .io_interface
+                .disconnect_from_peer(peer_index)
+                .await;
+        }
     }
 }
 


### PR DESCRIPTION
Restores previously commented-out code for managing congested peers, enabling automatic disconnection of peers identified as congested. This improves network stability by ensuring timely handling of congested connections.

#137