### PR TITLE
scaffold signalling for two lite clients with same publickey

### DIFF
--- a/node/lib/saito/browser.ts
+++ b/node/lib/saito/browser.ts
@@ -10,6 +10,7 @@ const emoji = require('node-emoji');
 const UserMenu = require('./ui/modals/user-menu/user-menu');
 const SaitoCrypto = require('./ui/saito-crypto/saito-crypto');
 const SaitoNFTOverlayManager = require('./ui/saito-nft/nft-overlay-manager');
+const SaitoScreenSaver = require('./ui/saito-screensaver/saito-screensaver');
 const debounce = require('lodash/debounce');
 const SaitoMentions = require('./ui/saito-mentions/saito-mentions');
 
@@ -160,27 +161,6 @@ class Browser {
           }
         };
 
-        /***** channel.onmessage = async (e) => {
-          console.log("document onmessage change");
-          if (!document[this.hidden_tab_property]) {
-          channel.postMessage({active: 1, publicKey: publicKey});
-          this.setActiveTab(1);
-          } else {
-          //
-          // only disable if someone else active w/ same key
-          //
-          if (e.data) {
-            if (e.data.active == 1) {
-            if (e.data.active == 1 && e.data.publicKey === publicKey) {
-              this.setActiveTab(0);
-              salert("Saito is already open in another tab");
-            }
-            }
-          }
-          }
-        };
-*****/
-
         document.addEventListener(
           this.tab_event_name,
           () => {
@@ -283,6 +263,12 @@ class Browser {
       // crypto overlays, add so events will listen
       //
       this.saito_crypto = new SaitoCrypto(this.app, this.app.modules.returnActiveModule());
+      this.screen_saver = new SaitoScreenSaver(this.app);
+      this.screen_saver.initialize(this.app);
+      //
+      // Browsers default to a hibernate state
+      //
+      this.hibernate = true; // this opts out of sending transactions until we know we are the commanding pki
 
       this.saito_nft_manager = new SaitoNFTOverlayManager(this.app);
       this.saito_nft_manager.initialize(this.app);
@@ -292,7 +278,6 @@ class Browser {
       // gracefully return out after warning user.
       //
       this.checkForMultipleWindows();
-      //this.isFirstVisit();
 
       //if ('serviceWorker' in navigator) {
       //    await navigator.serviceWorker
@@ -315,13 +300,16 @@ class Browser {
 
       this.updateThemeInHeader(theme);
 
+      //
+      // Mobile window height correction
+      //
       const updateViewHeight = () => {
         let vh = window.innerHeight / 100;
         document.documentElement.style.setProperty('--saito-vh', `${vh}px`);
-        //siteMessage(`Update: ${vh}px`);
       };
 
       window.addEventListener('resize', debounce(updateViewHeight, 200));
+
       setTimeout(() => {
         updateViewHeight();
       }, 200);
@@ -665,16 +653,10 @@ class Browser {
   }
 
   //
-  // toggle active tab and disable / enable core blockchain
-  // functionality as needed.
+  // toggle active tab
   //
   async setActiveTab(active) {
     this.active_tab = active;
-    this.app.blockchain.process_blocks = active;
-    this.app.storage.save_options = active;
-    for (let peer of await this.app.network.getPeers()) {
-      peer.handle_peer_requests = active;
-    }
   }
 
   //////////////////////////////////

--- a/node/lib/saito/network.ts
+++ b/node/lib/saito/network.ts
@@ -17,6 +17,14 @@ export default class Network {
   }
 
   public async propagateTransaction(tx: Transaction) {
+    /*
+      Ideally, we would add the tx to the pending list, and if the other instance successfully sends it
+      remove it from pending...
+    */
+    if (this.app.BROWSER && this.app.browser.hibernate) {
+      console.warn('Hibernating lite node will not send transactions');
+      return false;
+    }
     return S.getInstance().propagateTransaction(tx);
   }
 

--- a/node/lib/saito/ui/saito-screensaver/saito-screensaver.js
+++ b/node/lib/saito/ui/saito-screensaver/saito-screensaver.js
@@ -1,0 +1,102 @@
+const SaitoOverlay = require('../saito-overlay/saito-overlay');
+const ScreenSaverTemplate = require('./saito-screensaver.template');
+const UIModTemplate = require('./../../../templates/uimodtemplate');
+
+class SaitoScreenSaver extends UIModTemplate {
+  constructor(app) {
+    super(app);
+
+    this.app = app;
+    this.name = 'ScreenSaver';
+
+    this.time_online = null;
+    this.device = null;
+    this.overlay = new SaitoOverlay(this.app, this, false);
+  }
+
+  async initialize(app) {
+    await super.initialize(app);
+    //
+    // We want to store a device ID outside of the wallet, so we can know where we are
+    //
+    this.device = localStorage.getItem('saito-device') || null;
+    if (!this.device) {
+      this.device = navigator.userAgent + Math.floor(10000 * Math.random());
+      this.addDevice(this.device);
+      localStorage.setItem('saito-device', this.device);
+    }
+  }
+
+  async onPeerServiceUp(app, peer, service = {}) {
+    if (service.service == 'relay') {
+      if (!this.time_online) {
+        console.log('+++++++++++++++++++++++\nSending online message');
+        this.time_online = Date.now();
+        this.app.browser.hibernate = false;
+        this.app.connection.emit('relay-send-message', {
+          recipient: this.publicKey,
+          request: 'screensaver',
+          data: { ts: this.time_online, device: this.device }
+        });
+        this.app.browser.hibernate = true;
+      }
+    }
+  }
+
+  async handlePeerTransaction(app, tx = null, peer, mycallback) {
+    if (tx.isTo(this.publicKey)) {
+      let txmsg = tx.returnMessage();
+      console.log('+++++++++++++++++++++', txmsg);
+      if (txmsg.request == 'screensaver') {
+        if (txmsg.data.device !== this.device) {
+          this.app.browser.hibernate = true;
+          this.render(txmsg.data);
+        } else {
+          this.app.browser.hibernate = false;
+        }
+      }
+    }
+  }
+
+  render(details) {
+    this.overlay.render(ScreenSaverTemplate(details));
+    this.overlay.blockClose();
+    this.attachEvents();
+  }
+
+  attachEvents() {
+    if (document.getElementById('wake-up-button')) {
+      document.getElementById('wake-up-button').onclick = (e) => {
+        this.app.browser.hibernate = false;
+        this.time_online = Date.now();
+        this.app.connection.emit('relay-send-message', {
+          recipient: this.publicKey,
+          request: 'screensaver',
+          data: { ts: this.time_online, device: this.device }
+        });
+        //
+        // Stay in hibernation mode until confirmed
+        //
+        this.app.browser.hibernate = true;
+      };
+    }
+  }
+
+  addDevice(device) {
+    if (!this.app.options.devices) {
+      this.app.options.devices = [];
+    }
+
+    for (let d of this.app.options.devices) {
+      if (d == device) {
+        return;
+      }
+    }
+
+    this.app.options.devices.push(device);
+
+    this.app.storage.saveOptions();
+  }
+}
+
+module.exports = SaitoScreenSaver;

--- a/node/lib/saito/ui/saito-screensaver/saito-screensaver.template.js
+++ b/node/lib/saito/ui/saito-screensaver/saito-screensaver.template.js
@@ -1,0 +1,10 @@
+module.exports = (details) => {
+  return `
+  <div class="saito-screensaver">
+  <h2>Device Hibernating</h2>
+  <div class="saito-info">Your public key ${details.recipient} is logged in on another device. This browser will remain in a sleep state so that you don't accidentally send duplicate transactions from multiple lite nodes. Click 'Reconnect' to switch control back to this device.</div>
+  <div class="saito-info-box">Device: ${details.device}</div>
+  <button id="wake-up-button" class="saito-button-primary">Reconnect</button>
+  </div>
+  `;
+};

--- a/node/lib/saito/wallet.ts
+++ b/node/lib/saito/wallet.ts
@@ -1064,6 +1064,8 @@ export default class Wallet extends SaitoWallet {
   // for backup purposes
   //
   exportWallet() {
+    this.app.options.wallet.ts = Date.now();
+
     let newObj = JSON.parse(JSON.stringify(this.app.options));
 
     delete newObj.games;
@@ -1080,8 +1082,6 @@ export default class Wallet extends SaitoWallet {
         let publicKey = await this.getPublicKey();
 
         delete this.app.options.wallet.backup_required;
-
-        await this.saveWallet();
         this.app.connection.emit('saito-header-update-message');
 
         //let content = JSON.stringify(this.app.options);
@@ -1095,6 +1095,8 @@ export default class Wallet extends SaitoWallet {
         document.body.appendChild(pom);
         pom.click();
         pom.remove();
+
+        await this.saveWallet();
       }
     } catch (err) {
       console.log('Error backing-up wallet: ' + err);

--- a/node/mods/archive/archive.js
+++ b/node/mods/archive/archive.js
@@ -115,10 +115,13 @@ class Archive extends ModTemplate {
 				}
 			}
 
-			setTimeout(() => {
+			/*
+			This is done, presumably...
+				setTimeout(() => {
 				console.log('######### START CONVERSIONS ##############');
 				convertToFS();
 			}, 30000);
+			*/
 		}
 
 		let now = new Date().getTime();

--- a/node/mods/mixin/sql/mixin_payments_requests.sql
+++ b/node/mods/mixin/sql/mixin_payments_requests.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS mixin_payments_requests (
   id                   INTEGER PRIMARY KEY AUTOINCREMENT,
   request_id           INTEGER NOT NULL,
-  requested_by         TEXT NOT NULL
-  amount               TEXT NOT NULL
+  requested_by         TEXT NOT NULL,
+  amount               TEXT NOT NULL,
   tx                   TEXT NOT NULL,
   status               TEXT NOT NULL CHECK ( status IN ('unpaid', 'paid') ),
   created_at           INTEGER NOT NULL,

--- a/node/mods/recovery/recovery.js
+++ b/node/mods/recovery/recovery.js
@@ -54,6 +54,19 @@ class Recovery extends ModTemplate {
 		});
 	}
 
+	async initialize(app) {
+		await super.initialize(app);
+
+		/// Clean up detritus in the wallet
+		if (this.app.options.wallet) {
+			delete this.app.options.wallet.account_recovery_hash;
+			delete this.app.options.wallet.account_recovery_secret;
+			delete this.app.options.wallet.backup_required_msg;
+
+			this.app.storage.saveOptions();
+		}
+	}
+
 	returnDecryptionSecret(email = '', pass = '') {
 		let hash1 = 'WHENINDISGRACEWITHFORTUNEANDMENSEYESIALLALONEBEWEEPMYOUTCASTSTATE';
 		let hash2 = 'ANDTROUBLEDEAFHEAVENWITHMYBOOTLESSCRIESANDLOOKUPONMYSELFANDCURSEMYFATE';

--- a/node/mods/relay/relay.js
+++ b/node/mods/relay/relay.js
@@ -111,6 +111,11 @@ class Relay extends ModTemplate {
   }
 
   async sendRelayTransaction(tx) {
+    if (this.app.BROWSER && this.app.browser.hibernate) {
+      console.warn("Don't relay transactions in hibernation state");
+      return false;
+    }
+
     let need_server = true;
     if (this.stun) {
       need_server = false;


### PR DESCRIPTION
** DO NOT MERGE **

This is a template of how I would handle dual browser management for the same public key.

The main idea is lite clients store a flag "hibernate" in app.browser, which prevents them from sending transactions (in Relay and network.ts), but they can still receive and process. When a lite client comes online, it sends an offchain notice and takes control. Any other copy of the public key goes into hibernation and displays an overlay with a big button that allows it to resume control. 

Of course, this is all theoretical because the wasm code won't accept two peers with the same publickey. It would also be better to insert the control more into the wasm code, so that we send the signal as part of the initial handshake and we block propagateTransaction after the tx gets added to pending transactions but before it gets sent to the network.

Otherwise, it is quite simple and demonstrates how a ui component instantiated by app.browser can inherit module functionality