### PR TITLE
Rust side of Issue #676

### DIFF
--- a/rust/saito-rust/src/config_handler.rs
+++ b/rust/saito-rust/src/config_handler.rs
@@ -1,4 +1,5 @@
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
+use saito_core::core::defs::{PrintForLog, SaitoPrivateKey};
 use saito_core::core::util::configuration::{
     BlockchainConfig, Configuration, ConsensusConfig, Endpoint, PeerConfig, Server, WalletConfig,
 };
@@ -121,6 +122,82 @@ fn looks_like_json(s: &str) -> bool {
     trimmed.starts_with('{') || trimmed.starts_with('[')
 }
 
+fn is_valid_private_key(value: &str) -> bool {
+    SaitoPrivateKey::from_hex(value).is_ok()
+}
+
+fn saito_pass() -> Option<String> {
+    std::env::var("SAITO_PASS").ok()
+}
+
+/// the config file itself is plaintext json. only the wallet private key is encrypted at rest,
+/// and only when a password is set. an empty key is left alone since there's nothing to protect.
+fn encrypt_private_key_for_saving(
+    value: &mut serde_json::Value,
+    pass: Option<&str>,
+) -> Result<(), Error> {
+    let pass = match pass {
+        Some(pass) => pass,
+        None => return Ok(()),
+    };
+    let private_key = match value.pointer("/wallet/privateKey").and_then(|k| k.as_str()) {
+        Some(key) => key,
+        None => return Ok(()),
+    };
+    if private_key.is_empty() || private_key.starts_with(ENC_HEADER) {
+        return Ok(());
+    }
+    let encrypted = encrypt_bytes(pass, private_key.as_bytes())?;
+    value["wallet"]["privateKey"] = serde_json::Value::String(encrypted);
+    Ok(())
+}
+
+/// counterpart of [`encrypt_private_key_for_saving`]. a key which already parses as a private key
+/// is used as-is, anything else is assumed to be ciphertext and needs the password to unlock.
+fn decrypt_private_key_after_loading(
+    configs: &mut NodeConfigurations,
+    pass: Option<&str>,
+) -> Result<(), Error> {
+    let wallet = match configs.wallet.as_mut() {
+        Some(wallet) => wallet,
+        None => return Ok(()),
+    };
+    if wallet.private_key.is_empty() || is_valid_private_key(&wallet.private_key) {
+        return Ok(());
+    }
+
+    let pass = pass.ok_or_else(|| {
+        error!(
+            "the wallet private key in the config file is encrypted but SAITO_PASS is not set. \
+             set SAITO_PASS to the password it was encrypted with, or replace the privateKey \
+             value with a plaintext key."
+        );
+        Error::from(ErrorKind::InvalidInput)
+    })?;
+
+    let decrypted = decrypt_bytes(pass, &wallet.private_key)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .filter(|key| is_valid_private_key(key))
+        .ok_or_else(|| {
+            error!(
+                "could not decrypt the wallet private key in the config file. SAITO_PASS is \
+                 most likely incorrect. the config file has not been modified."
+            );
+            Error::from(ErrorKind::InvalidInput)
+        })?;
+
+    wallet.private_key = decrypted;
+    Ok(())
+}
+
+/// write via a sibling temp file so an interrupted save can't leave a half-written config behind
+fn write_config_file(path: &str, contents: &[u8]) -> Result<(), Error> {
+    let temp_path = format!("{}.tmp", path);
+    std::fs::write(&temp_path, contents)?;
+    std::fs::rename(&temp_path, path)
+}
+
 impl Configuration for NodeConfigurations {
     fn get_server_configs(&self) -> Option<&Server> {
         Some(&self.server)
@@ -169,15 +246,10 @@ impl Configuration for NodeConfigurations {
 
     fn save(&self) -> Result<(), Error> {
         let config_file_path = self.get_config_path();
-        let json_bytes = serde_json::to_vec_pretty(&self)?;
-        if let Ok(pass) = std::env::var("SAITO_PASS") {
-            let enc = encrypt_bytes(&pass, &json_bytes)?;
-            std::fs::write(config_file_path, enc.as_bytes())?;
-        } else {
-            let file = std::fs::File::create(config_file_path)?;
-            serde_json::to_writer_pretty(&file, &self)?;
-        }
-        Ok(())
+        let mut value = serde_json::to_value(self)?;
+        encrypt_private_key_for_saving(&mut value, saito_pass().as_deref())?;
+        let json = serde_json::to_string_pretty(&value)?;
+        write_config_file(&config_file_path, json.as_bytes())
     }
     fn get_config_path(&self) -> String {
         self.config_path.clone()
@@ -225,31 +297,31 @@ impl ConfigHandler {
             configs.set_config_path(config_file_path.clone());
             configs.save()?;
         }
-        // Read file; supports encrypted or plaintext
+        let pass = saito_pass();
+
+        // Read file; plaintext json, or a legacy fully encrypted config we migrate away from
         let raw = std::fs::read_to_string(config_file_path.clone())?;
-        let content = if raw.starts_with(ENC_HEADER) {
-            let pass = std::env::var("SAITO_PASS").map_err(|_| {
-                error!("SAITO_PASS not set for encrypted config file");
+        let content = if looks_like_json(&raw) {
+            raw
+        } else {
+            let pass = pass.as_deref().ok_or_else(|| {
+                error!(
+                    "the config file is not json and SAITO_PASS is not set. legacy fully \
+                     encrypted config files need SAITO_PASS to be read."
+                );
                 std::io::Error::from(ErrorKind::InvalidInput)
             })?;
-            let decrypted = decrypt_bytes(&pass, &raw)?;
+            // legacy format : the whole file was encrypted, with or without the ENC1: header
+            let decrypted = decrypt_bytes(pass, &raw).map_err(|_| {
+                error!("failed loading configs: unrecognized format and decryption failed");
+                std::io::Error::from(ErrorKind::InvalidInput)
+            })?;
+            warn!(
+                "loaded a legacy fully encrypted config file. it will be rewritten as plaintext \
+                 json with only the wallet private key encrypted on the next save."
+            );
             String::from_utf8(decrypted)
                 .map_err(|_| std::io::Error::from(ErrorKind::InvalidInput))?
-        } else if looks_like_json(&raw) {
-            raw
-        } else if let Ok(pass) = std::env::var("SAITO_PASS") {
-            // Try decrypting even without header
-            match decrypt_bytes(&pass, &raw) {
-                Ok(bytes) => String::from_utf8(bytes)
-                    .map_err(|_| std::io::Error::from(ErrorKind::InvalidInput))?,
-                Err(_) => {
-                    error!("failed loading configs: unrecognized format and decryption failed");
-                    return Err(std::io::Error::from(ErrorKind::InvalidInput));
-                }
-            }
-        } else {
-            error!("failed loading configs: unrecognized format and SAITO_PASS not set");
-            return Err(std::io::Error::from(ErrorKind::InvalidInput));
         };
 
         let configs = serde_json::from_str::<NodeConfigurations>(&content);
@@ -260,6 +332,7 @@ impl ConfigHandler {
         }
         let mut configs = configs.unwrap();
         configs.set_config_path(config_file_path.clone());
+        decrypt_private_key_after_loading(&mut configs, pass.as_deref())?;
 
         Ok(configs)
     }
@@ -269,9 +342,9 @@ impl ConfigHandler {
 mod test {
     use std::io::ErrorKind;
 
-    use saito_core::core::util::configuration::Configuration;
+    use saito_core::core::util::configuration::{Configuration, WalletConfig};
 
-    use crate::config_handler::ConfigHandler;
+    use super::*;
 
     #[test]
     #[ignore]
@@ -317,5 +390,144 @@ mod test {
         let path = String::from("config/new_file_to_write.json");
         let result = ConfigHandler::load_configs(path);
         assert!(result.is_ok());
+    }
+
+    const TEST_PRIVATE_KEY: &str =
+        "854702489d49c7fb2334005b903580c7a48fe81121ff16ee6d1a528ad32f235d";
+
+    #[test]
+    fn private_key_validation() {
+        assert!(is_valid_private_key(TEST_PRIVATE_KEY));
+        assert!(!is_valid_private_key(""));
+        assert!(!is_valid_private_key("not a key"));
+        // right length, wrong alphabet
+        assert!(!is_valid_private_key(&"z".repeat(64)));
+        // right alphabet, wrong length
+        assert!(!is_valid_private_key(&TEST_PRIVATE_KEY[..62]));
+        // ciphertext must never be mistaken for a key
+        let encrypted = encrypt_bytes("pass", TEST_PRIVATE_KEY.as_bytes()).unwrap();
+        assert!(!is_valid_private_key(&encrypted));
+    }
+
+    #[test]
+    fn private_key_encryption_round_trip() {
+        let encrypted = encrypt_bytes("correct horse", TEST_PRIVATE_KEY.as_bytes()).unwrap();
+        assert!(encrypted.starts_with(ENC_HEADER));
+
+        let decrypted = decrypt_bytes("correct horse", &encrypted).unwrap();
+        assert_eq!(String::from_utf8(decrypted).unwrap(), TEST_PRIVATE_KEY);
+
+        assert!(decrypt_bytes("wrong pass", &encrypted).is_err());
+    }
+
+    #[test]
+    fn saved_private_key_is_encrypted_in_place() {
+        let mut value = serde_json::json!({
+            "server": { "host": "127.0.0.1" },
+            "wallet": { "publicKey": "abc", "privateKey": TEST_PRIVATE_KEY }
+        });
+
+        encrypt_private_key_for_saving(&mut value, Some("hunter2")).unwrap();
+
+        // the rest of the config stays readable
+        assert_eq!(value["server"]["host"], "127.0.0.1");
+        assert_eq!(value["wallet"]["publicKey"], "abc");
+
+        let stored = value["wallet"]["privateKey"].as_str().unwrap();
+        assert_ne!(stored, TEST_PRIVATE_KEY);
+        assert!(stored.starts_with(ENC_HEADER));
+        assert_eq!(
+            String::from_utf8(decrypt_bytes("hunter2", stored).unwrap()).unwrap(),
+            TEST_PRIVATE_KEY
+        );
+    }
+
+    #[test]
+    fn saved_private_key_is_plaintext_without_pass() {
+        let mut value = serde_json::json!({
+            "wallet": { "privateKey": TEST_PRIVATE_KEY }
+        });
+
+        encrypt_private_key_for_saving(&mut value, None).unwrap();
+
+        assert_eq!(value["wallet"]["privateKey"], TEST_PRIVATE_KEY);
+    }
+
+    #[test]
+    fn saving_never_double_encrypts() {
+        let encrypted = encrypt_bytes("hunter2", TEST_PRIVATE_KEY.as_bytes()).unwrap();
+        let mut value = serde_json::json!({
+            "wallet": { "privateKey": encrypted }
+        });
+
+        encrypt_private_key_for_saving(&mut value, Some("hunter2")).unwrap();
+
+        assert_eq!(value["wallet"]["privateKey"], encrypted);
+    }
+
+    fn configs_with_private_key(private_key: &str) -> NodeConfigurations {
+        NodeConfigurations {
+            wallet: Some(WalletConfig {
+                public_key: String::new(),
+                private_key: private_key.to_string(),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn plaintext_private_key_loads_unchanged() {
+        // a plaintext key is used as-is whether or not a password is set
+        for pass in [Some("hunter2"), None] {
+            let mut configs = configs_with_private_key(TEST_PRIVATE_KEY);
+            decrypt_private_key_after_loading(&mut configs, pass).unwrap();
+            assert_eq!(
+                configs.get_wallet_configs().unwrap().private_key,
+                TEST_PRIVATE_KEY
+            );
+        }
+    }
+
+    #[test]
+    fn encrypted_private_key_loads_with_correct_pass() {
+        let encrypted = encrypt_bytes("hunter2", TEST_PRIVATE_KEY.as_bytes()).unwrap();
+        let mut configs = configs_with_private_key(&encrypted);
+
+        decrypt_private_key_after_loading(&mut configs, Some("hunter2")).unwrap();
+
+        assert_eq!(
+            configs.get_wallet_configs().unwrap().private_key,
+            TEST_PRIVATE_KEY
+        );
+    }
+
+    #[test]
+    fn encrypted_private_key_fails_without_pass() {
+        let encrypted = encrypt_bytes("hunter2", TEST_PRIVATE_KEY.as_bytes()).unwrap();
+        let mut configs = configs_with_private_key(&encrypted);
+
+        let result = decrypt_private_key_after_loading(&mut configs, None);
+
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+        // the in-memory key is untouched, so nothing can be written back over the config
+        assert_eq!(configs.get_wallet_configs().unwrap().private_key, encrypted);
+    }
+
+    #[test]
+    fn encrypted_private_key_fails_with_wrong_pass() {
+        let encrypted = encrypt_bytes("hunter2", TEST_PRIVATE_KEY.as_bytes()).unwrap();
+        let mut configs = configs_with_private_key(&encrypted);
+
+        let result = decrypt_private_key_after_loading(&mut configs, Some("hunter3"));
+
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidInput);
+        assert_eq!(configs.get_wallet_configs().unwrap().private_key, encrypted);
+    }
+
+    #[test]
+    fn empty_private_key_is_left_alone() {
+        let mut configs = configs_with_private_key("");
+        decrypt_private_key_after_loading(&mut configs, None).unwrap();
+        assert_eq!(configs.get_wallet_configs().unwrap().private_key, "");
     }
 }


### PR DESCRIPTION
I didn't even realize that the SAITO_PASS encryption of options files was also happening in the Rust side, but if we want to only encyrpt the private_key so as to more easily edit the options files, these changes may be necessary.